### PR TITLE
Remove njabl

### DIFF
--- a/list.json
+++ b/list.json
@@ -10,11 +10,6 @@
         "site": "http://spamcop.net" 
     },
     {
-        "name": "Not Just Another Blacklist",
-        "dns": "dnsbl.njabl.org",
-        "site": "http://njabl.org"
-    },
-    {
         "name": "Sorbs Aggregate Zone",
         "dns": "dnsbl.sorbs.net",
         "site": "http://dnsbl.sorbs.net/"


### PR DESCRIPTION
As per their accouncement, njabl is shutting down. Removed consequently.

More info: http://njabl.org/ .
